### PR TITLE
No longer require font helvetica. Fixes issue #3.

### DIFF
--- a/src/X48.ad
+++ b/src/X48.ad
@@ -33,7 +33,7 @@
 *smallLabelFont:	-*-fixed-bold-r-normal-*-14-*-*-*-*-*-iso8859-1
 *mediumLabelFont:	-*-fixed-bold-r-normal-*-15-*-*-*-*-*-iso8859-1
 *largeLabelFont:	-*-fixed-medium-r-normal-*-20-*-*-*-*-*-iso8859-1
-*connectionFont:	-*-helvetica-medium-r-normal-*-12-*-*-*-*-*-iso8859-1
+*connectionFont:	-*-fixed-medium-r-normal-*-12-*-*-*-*-*-iso8859-1
 
 !
 ! informative stuff

--- a/src/X48.ad.h
+++ b/src/X48.ad.h
@@ -7,7 +7,7 @@
 "*smallLabelFont:	-*-fixed-bold-r-normal-*-14-*-*-*-*-*-iso8859-1",
 "*mediumLabelFont:	-*-fixed-bold-r-normal-*-15-*-*-*-*-*-iso8859-1",
 "*largeLabelFont:	-*-fixed-medium-r-normal-*-20-*-*-*-*-*-iso8859-1",
-"*connectionFont:	-*-helvetica-medium-r-normal-*-12-*-*-*-*-*-iso8859-1",
+"*connectionFont:	-*-fixed-medium-r-normal-*-12-*-*-*-*-*-iso8859-1",
 "*verbose:		False",
 "*quiet:			False",
 "*printVersion:		False",


### PR DESCRIPTION
That font is not always available by default
and not essential to the program.

Workaround no longer needed.
Tested also with generation of Debian package: works.
