### PR TITLE
fixed clang error "debugger.c:1031:3: error: non-void function 'get_stack' should return a value"

### DIFF
--- a/src/debugger.c
+++ b/src/debugger.c
@@ -982,7 +982,7 @@ struct se {
   struct se *se_next;
 };
 
-char *get_stack(void) {
+void get_stack(void) {
   word_20 dsktop, dskbot;
   word_20 sp = 0, end = 0, ent = 0;
   word_20 ram_base, ram_mask;


### PR DESCRIPTION
```
debugger.c:1031:3: error: non-void function 'get_stack' should return a value [-Wreturn-type]
1031 | return;
| ^
2 warnings and 1 error generated.
make[2]: *** [debugger.o] Error 1
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```

Fixed compilation error with clang
```
clang --version

Homebrew clang version 17.0.6
Target: x86_64-apple-darwin23.2.0
Thread model: posix
InstalledDir: /usr/local/opt/llvm/bin
```